### PR TITLE
Add field codecTagString for differentiation of subcodecs

### DIFF
--- a/src/main/kotlin/se/svt/oss/mediaanalyzer/MediaAnalyzer.kt
+++ b/src/main/kotlin/se/svt/oss/mediaanalyzer/MediaAnalyzer.kt
@@ -137,7 +137,8 @@ class MediaAnalyzer
                 bitDepth = ffVideoStream.bits_per_raw_sample ?: videoTrack?.bitDepth,
                 numFrames = numFrames,
                 isInterlaced = interlaced,
-                transferCharacteristics = videoTrack?.transferCharacteristics
+                transferCharacteristics = videoTrack?.transferCharacteristics,
+                codecTagString = ffVideoStream.codec_tag_string
             )
         }
     }

--- a/src/main/kotlin/se/svt/oss/mediaanalyzer/file/VideoStream.kt
+++ b/src/main/kotlin/se/svt/oss/mediaanalyzer/file/VideoStream.kt
@@ -20,5 +20,6 @@ data class VideoStream(
     val bitDepth: Int?,
     val numFrames: Int,
     val isInterlaced: Boolean,
-    val transferCharacteristics: String?
+    val transferCharacteristics: String?,
+    val codecTagString: String
 )

--- a/src/main/kotlin/se/svt/oss/mediaanalyzer/file/VideoStream.kt
+++ b/src/main/kotlin/se/svt/oss/mediaanalyzer/file/VideoStream.kt
@@ -21,5 +21,5 @@ data class VideoStream(
     val numFrames: Int,
     val isInterlaced: Boolean,
     val transferCharacteristics: String?,
-    val codecTagString: String
+    val codecTagString: String?
 )

--- a/src/test/kotlin/se/svt/oss/mediaanalyzer/MediaAnalyzerIntegrationTest.kt
+++ b/src/test/kotlin/se/svt/oss/mediaanalyzer/MediaAnalyzerIntegrationTest.kt
@@ -52,6 +52,7 @@ class MediaAnalyzerIntegrationTest {
             .hasBitDepth(10)
             .hasNumFrames(250)
             .hasTransferCharacteristics(null)
+            .hasCodecTagString("avc1")
 
         assertThat(videoFile.audioStreams).hasSize(1)
         assertThat(videoFile.audioStreams)


### PR DESCRIPTION
# Pull Request Template

## Description

Adds the field `codecTagString` to the `VideoStream` model. This is useful in situations where "subcodecs" are used and further differentiation is needed, for example HEVC with dolby vision (tag string `dvh1`), or different flavors of AAC.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
## How Has This Been Tested?
Added check in integration test.
Please delete options that are not relevant.

## Checklist:

- [x ] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)

