### PR TITLE
More lenient deserialization of mediainfo other track

### DIFF
--- a/src/main/kotlin/se/svt/oss/mediaanalyzer/mediainfo/OtherTrack.kt
+++ b/src/main/kotlin/se/svt/oss/mediaanalyzer/mediainfo/OtherTrack.kt
@@ -8,6 +8,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class OtherTrack(
-    override val format: String,
+    override val format: String = "UNKNOWN",
     override val extra: Map<String, Any> = emptyMap()
 ) : Track

--- a/src/test/resources/mediainfo-reg.json
+++ b/src/test/resources/mediainfo-reg.json
@@ -82,6 +82,10 @@
         "Delay_Source": "Stream",
         "StreamSize": "71362560",
         "StreamSize_Proportion": "0.05333"
+      },
+      {
+        "@type": "Menu",
+        "ID": "1"
       }
     ]
   }


### PR DESCRIPTION
Support for media info tracks without format being deserialized as OtherTrack